### PR TITLE
Renames from bs12

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,11 @@
 .git
 !.git/HEAD
 !.git/logs/HEAD
-baystation12.dmb
-baystation12.rsc
-baystation12.dyn.rsc
-baystation12.dyn.rsc.lk
-baystation12.int
+jonsperiments.dmb
+jonsperiments.rsc
+jonsperiments.dyn.rsc
+jonsperiments.dyn.rsc.lk
+jonsperiments.int
 libmysql.dll
 .dockerignore
 Dockerfile

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 All users are expected to review [/docs/CODE_OF_CONDUCT.md](/docs/CODE_OF_CONDUCT.md) before interacting with the repository or other users.
 
-Baystation12 is licensed under the GNU Affero General Public License version 3, which can be found in full in LICENSE-AGPL3.txt.
+jonsperiments is licensed under the GNU Affero General Public License version 3, which can be found in full in LICENSE-AGPL3.txt.
 
 Commits with a git authorship date prior to `1420675200 +0000` (2015/01/08 00:00 GMT) are licensed under the GNU General Public License version 3, which can be found in full in LICENSE-GPL3.txt.
 
 All commits whose authorship dates on or after `1420675200 +0000` are assumed to be licensed under AGPL v3, if you wish to license under GPL v3 please make this clear in the commit message and any added files.
+
+Note unless otherwise specified this codebase considers the intellectual property regarding creative content (i.e. not source code) committed to this repository to remain with the original creator but permission obviously granted for usage of that content in this codebase and any other compatible SS13 codebases that the content may be ported to. I.E. original rights to any fictional places, characters, events, technologies, etc. remain under the ownership of their creator and are not granted in any way for usage outside of the context of SS13 codebases.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -50,4 +50,4 @@
 - [ ] Issue could be reproduced by different players
 - [ ] Issue could be reproduced in multiple rounds
 - [ ] Issue happened in a recent (less than 7 days ago) round
-- [ ] [Couldn't find an existing issue about this](https://github.com/Baystation12/Baystation12/issues)
+- [ ] [Couldn't find an existing issue about this](https://github.com/Baystation12/Baystation12/issues and https://github.com/Jonsperiments/Jonsperiments2019/issues)

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ Session.vim
 
 # auto-generated tag files
 tags
-baystation12.code-workspace
+jonsperiments.code-workspace
 
 # ignore built libs
 lib/*.dll

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=0 /byhttp/to_copy /bs12/lib
 
 WORKDIR /bs12
 RUN apt-get update && apt-get install -y gosu
-RUN scripts/dm.sh $BUILD_ARGS baystation12.dme
+RUN scripts/dm.sh $BUILD_ARGS jonsperiments.dme
 
 EXPOSE 8000
 VOLUME /bs12/data

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# baystation12
+# jonsperiments
 
-[Website](http://baystation12.net/) - [Code](http://github.com/Baystation12/Baystation12/) - [Discord](https://discord.gg/DrtRFxs) - [IRC](irc://irc.sorcery.net/#codershuttle)
+[Code](http://github.com/Jonsperiments/Jonsperiments2019/)
 
 ---
 
@@ -20,7 +20,7 @@ Please see [/docs/SECURITY.md](/docs/SECURITY.md) for this repository's security
 
 ### LICENSE
 
-The code for Baystation12 is licensed under the [GNU Affero General Public License v3](http://www.gnu.org/licenses/agpl.html), which can be found in full in [/LICENSE](/LICENSE).
+The code for jonsperiments is licensed under the [GNU Affero General Public License v3](http://www.gnu.org/licenses/agpl.html), which can be found in full in [/LICENSE](/LICENSE).
 
 Code with a git authorship date prior to `1420675200 +0000` (2015/01/08 00:00 GMT) is licensed under the GNU General Public License version 3, which can be found in full in [/docs/GPL3.txt](/docs/GPL3.txt)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,10 +2,10 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  imageName: 'registry.baystation12.net/baystation12:latest'
+  imageName: 'jonsperiments [not needed for now]'
 
 steps:
-- script: git clone https://github.com/Baystation12/custom-items
+- script: git clone https://github.com/Jonsperiments/custom-items
   displayName: 'clone custom items'
 
 - task: Docker@0
@@ -18,7 +18,7 @@ steps:
   displayName: 'registry login'
   inputs:
     containerregistrytype: 'Container Registry'
-    dockerRegistryEndpoint: 'bs12'
+    dockerRegistryEndpoint: '[not needed for now]'
     command: login
 
 - task: Docker@1

--- a/code/_global_vars/configuration.dm
+++ b/code/_global_vars/configuration.dm
@@ -3,7 +3,7 @@ GLOBAL_VAR_INIT(max_explosion_range, 14)
 
 
 var/href_logfile        = null
-var/game_version        = "Baystation12"
+var/game_version        = "Jonsperiments"
 var/changelog_hash      = ""
 var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 288)
 var/join_motd = null

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -544,7 +544,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	s += "<b>[station_name()]</b>";
 	s += " ("
-	s += "<a href=\"https://forums.baystation12.net/\">" //Change this to wherever you want the hub to link to.
+	s += "<a href=\"https://github.com/Jonsperiments/Jonsperiments2019/\">" //Change this to wherever you want the hub to link to.
 //	s += "[game_version]"
 	s += "Forums"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
 	s += "</a>"

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -31,7 +31,7 @@ var/total_unit_tests = 0
 
 // For console out put in Linux/Bash makes the output green or red.
 // Should probably only be used for unit tests/Travis since some special folks use winders to host servers.
-// if you want plain output, use dm.sh -DUNIT_TEST -DUNIT_TEST_PLAIN baystation12.dme
+// if you want plain output, use dm.sh -DUNIT_TEST -DUNIT_TEST_PLAIN jonsperiments.dme
 #ifdef UNIT_TEST_PLAIN
 var/ascii_esc = ""
 var/ascii_red = ""

--- a/config/custom_items/README.md
+++ b/config/custom_items/README.md
@@ -1,1 +1,1 @@
-For details on how to use the custom item system, please refer to [the custom item repository](https://github.com/Baystation12/custom-items).
+For details on how to use the custom item system, please refer to [the custom item repository](https://github.com/Jonsperiments2019/custom-items).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 mkdir /byond
-chown $RUNAS:$RUNAS /byond /bs12 baystation12.rsc
+chown $RUNAS:$RUNAS /byond /bs12 jonsperiments.rsc
 
-gosu $RUNAS DreamDaemon baystation12.dmb 8000 -trusted -verbose
+gosu $RUNAS DreamDaemon jonsperiments.dmb 8000 -trusted -verbose

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-This repository is built and tested against BYOND version 512.1483 at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [.travis.yml](https://github.com/Baystation12/Baystation12/blob/dev/.travis.yml#L8) in the repository root folder, the Travis configuration should be considered authoritative and this document should be noted as out of date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
+This repository is built and tested against BYOND version 512.1483 at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [.travis.yml](https://github.com/Jonsperiments/Jonsperiments2019/blob/dev/.travis.yml#L8) in the repository root folder, the Travis configuration should be considered authoritative and this document should be noted as out of date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
 
 ## Reporting a Vulnerability
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,11 +2,11 @@
 
 The simplest way to obtain the code is using Github's .zip feature.
 
-Click [here](https://github.com/Baystation12/Baystation12/archive/dev.zip) to get the latest code as a .zip file, then unzip it to wherever you want.
+Click [here](https://github.com/Jonsperiments/Jonsperiments2019/archive/dev.zip) to get the latest code as a .zip file, then unzip it to wherever you want.
 
 The more complicated and easier to update method is using git.  You'll need to download git or some client from [here](http://git-scm.com/).  When that's installed, right click in any folder and click on "Git Bash".  When that opens, type in:
 
-    git clone https://github.com/Baystation12/Baystation12.git
+    git clone https://github.com/Jonsperiments/Jonsperiments2019.git
 
 (hint: hold down ctrl and press insert to paste into git bash)
 
@@ -18,11 +18,11 @@ This will take a while to download, but it provides an easier method for updatin
 
 First-time installation should be fairly straightforward.  First, you'll need BYOND installed.  You can get it from [here](http://www.byond.com/).
 
-This is a sourcecode-only release, so the next step is to compile the server files.  Open `baystation12.dme` by double-clicking it, open the Build menu, and click compile.  This'll take a little while, and if everything's done right you'll get a message like this:
+This is a sourcecode-only release, so the next step is to compile the server files.  Open `jonsperiments.dme` by double-clicking it, open the Build menu, and click compile.  This'll take a little while, and if everything's done right you'll get a message like this:
 
-    saving baystation12.dmb (DEBUG mode)
+    saving jonsperiments.dmb (DEBUG mode)
     
-    baystation12.dmb - 0 errors, 0 warnings
+    jonsperiments.dmb - 0 errors, 0 warnings
 
 If you see any errors or warnings, something has gone wrong - possibly a corrupt download or the files extracted wrong, or a code issue on the main repo.  Ask on IRC or discord.
 
@@ -40,7 +40,7 @@ Edit `admins.txt` to remove the default admins and add your own.  "Game Master" 
 
 where the BYOND key must be in lowercase and the admin rank must be properly capitalised.  There are a bunch more admin ranks, but these two should be enough for most servers, assuming you have trustworthy admins.
 
-To start the server, run Dream Daemon and enter the path to your compiled `baystation12.dmb` file.  Make sure to set the port to the one you  specified in the `config.txt`, and set the Security box to 'Trusted' so you don't have to confirm access to every single configuration and storage file for the server.  Then press GO and the server should start up and be ready to join.
+To start the server, run Dream Daemon and enter the path to your compiled `jonsperiments.dmb` file.  Make sure to set the port to the one you  specified in the `config.txt`, and set the Security box to 'Trusted' so you don't have to confirm access to every single configuration and storage file for the server.  Then press GO and the server should start up and be ready to join.
 
 ---
 

--- a/jonsperiments.dme
+++ b/jonsperiments.dme
@@ -1,4 +1,4 @@
-// DM Environment file for baystation12.dme.
+// DM Environment file for jonsperiments.dme.
 // All manual changes should be made outside the BEGIN_ and END_ blocks.
  // New source code should be placed in .dm files: choose File/New --> Code File.
 // BEGIN_INTERNALS

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-[[ -z $DME ]] && DME=baystation12 # DME file/BYOND project to compile and run
+[[ -z $DME ]] && DME=jonsperiments # DME file/BYOND project to compile and run
 [[ -z $PORT ]] && PORT=5000 # Port to run Dream Daemon on
 [[ -z $GIT ]] && GIT=false # true, false, or any valid command; return value decides whether git is called to update the code
 [[ -z $REPO ]] && REPO=upstream # Repo to fetch and pull from when updating

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This is the entrypoint to the testing system, written for Baystation12 and
+# This is the entrypoint to the testing system, written for jonsperiments and
 # inspired by Rust's configure system
 #
 # The tests are split up into groups by the `case` at the bottom, and the
@@ -229,11 +229,11 @@ function run_byond_tests {
         ./install-byond.sh || exit 1
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
-    run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
+    run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py jonsperiments.dme code/_helpers/global_access.dm"
     run_test "check globals unchanged" "md5sum -c - <<< '7c5e15cbffb4a7792c2c60179176ab90 *code/_helpers/global_access.dm'"
-    run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
+    run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH jonsperiments.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
-    run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"
+    run_test "run unit tests" "DreamDaemon jonsperiments.dmb -invisible -trusted -core 2>&1 | tee log.txt"
     run_test "check tests passed" "grep 'All Unit Tests Passed' log.txt"
     run_test "check no runtimes" "grep 'Caught 0 Runtimes' log.txt"
     run_test_fail "check no runtimes 2" "grep 'runtime error:' log.txt"

--- a/tools/GenerateGlobalVarAccess/generateGlobalVars.bat
+++ b/tools/GenerateGlobalVarAccess/generateGlobalVars.bat
@@ -1,3 +1,3 @@
 @echo off
-call python gen_globals.py ../../baystation12.dme ../../code/_helpers/global_access.dm
+call python gen_globals.py ../../jonsperiments.dme ../../code/_helpers/global_access.dm
 pause

--- a/tools/dmitool/merging.txt
+++ b/tools/dmitool/merging.txt
@@ -2,7 +2,7 @@
 2. Make sure java is in your PATH. To test this, open git bash, and type "java". If it says unknown command, you need to add JAVA/bin to your PATH variable (A guide for this can be found at https://www.java.com/en/download/help/path.xml ).
 
 Merging
-The easiest way to do merging is to install the merge driver. For this, open `Baystation12/.git/config` in a text editor, and paste the following lines to the end of it:
+The easiest way to do merging is to install the merge driver. For this, open `Jonsperiments/.git/config` in a text editor, and paste the following lines to the end of it:
 
 [merge "merge-dmi"]
 	name = iconfile merge driver


### PR DESCRIPTION
Renames bs12 references to "jonsperiments" - a single placeholder I can replace later if this is used for a named server, but I want to remove references to Bay (especially links for obvious reasons)
This should include all the github configs, docker configs, etc. even if not needed.
Some references to example configs, Bay issues or just old comments are retained because there's no sense in changing them.